### PR TITLE
file type update

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2104,7 +2104,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!120 &1034431354
 LineRenderer:
   serializedVersion: 2
@@ -2147,9 +2147,7 @@ LineRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Positions:
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 1, z: 0}
+  m_Positions: []
   m_Parameters:
     serializedVersion: 3
     widthMultiplier: 1

--- a/Assets/Scripts/Behaviours/River.cs
+++ b/Assets/Scripts/Behaviours/River.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -9,7 +10,6 @@ public class River : MonoBehaviour
 
     public void RegisterNewRiver(List<Clearing> newRiver)
     {
-        gameObject.SetActive(true);
         for (int i = 0; i < riverClearings.Count; i++)
         {
             riverClearings[i].OnClearingPositionChanged -= UpdateRiver;
@@ -61,18 +61,6 @@ public class River : MonoBehaviour
         }
     }
     
-    private void UpdateRiver()
-    {
-        List<Vector3> riverSpline = BezierSplineHelper.GetRiverSpline(riverClearings);
-
-        lineRenderer.positionCount = riverSpline.Count;
-
-        for (int i = 0; i < riverSpline.Count; i++)
-        {
-            lineRenderer.SetPosition(i, riverSpline[i]);
-        }
-    }
-
     public bool PathIsOnRiver(Clearing startClearing, Clearing endClearing)
     {
         for (int i = 0; i < riverClearings.Count; i++)
@@ -93,5 +81,22 @@ public class River : MonoBehaviour
         }
 
         return false;
+    }
+
+    public List<Clearing> GetRiverClearings()
+    {
+        return riverClearings;
+    }
+    
+    private void UpdateRiver()
+    {
+        List<Vector3> riverSpline = BezierSplineHelper.GetRiverSpline(riverClearings);
+
+        lineRenderer.positionCount = riverSpline.Count;
+
+        for (int i = 0; i < riverSpline.Count; i++)
+        {
+            lineRenderer.SetPosition(i, riverSpline[i]);
+        }
     }
 }

--- a/Assets/Scripts/Generators/FileGenerator.cs.meta
+++ b/Assets/Scripts/Generators/FileGenerator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 98a34426b8cbef34f939954beab0de3d
+guid: 2d055d75b47775840993414444bbeac2
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
The previous file type saved the following information on one line (clearingName, clearingPosition, clearingDenizen, factionControl, hasBuilding, hasSympathy). The new file type saves the following information on one line (clearingID, attributeID, attributeValues) i.e (0,0, clearingName). This should allow for easier implementation of new values that need to be saved.

The attribute IDs are as follows:
0 = name,
1 = position,
2 = denizen,
3 = factionControl
4 = hasBuilding,
5 = factionPresence